### PR TITLE
Change the sandbox register command

### DIFF
--- a/cookbook/Dockerfile
+++ b/cookbook/Dockerfile
@@ -31,8 +31,6 @@ COPY . /root
 RUN cp ${VENV}/bin/flytekit_venv /usr/local/bin/
 RUN chmod a+x /usr/local/bin/flytekit_venv
 
-#RUN ${VENV}/bin/pip install /root/flytekit-0.7.0b2.tar.gz
-
 # This tag is supplied by the build script and will be used to determine the version
 # when registering tasks, workflows, and launch plans
 ARG tag

--- a/cookbook/Makefile
+++ b/cookbook/Makefile
@@ -30,7 +30,7 @@ in_container_serialize_sandbox:
 
 # TODO: Get rid of the backticks in the future
 .PHONY: serialize_sandbox
-serialize_sandbox: docker_push
+serialize_sandbox: docker_build
 	mkdir `pwd`/_pb_output || true
 	docker run -v `pwd`/_pb_output:/tmp/output docker.io/lyft/flytecookbook:${VERSION} make in_container_serialize_sandbox
 

--- a/cookbook/Makefile
+++ b/cookbook/Makefile
@@ -3,18 +3,26 @@
 IMAGE_NAME=flytecookbook
 VERSION=$(shell ./version.sh)
 
+# If the REGISTRY environment variable has been set, that means the image name will not just be tagged as
+#   flytecookbook:<sha> but rather,
+#   docker.io/lyft/flytecookbook:<sha> or whatever your REGISTRY is.
+ifneq ($(origin REGISTRY), undefined)
+	FULL_IMAGE_NAME = ${REGISTRY}/${IMAGE_NAME}
+else
+	FULL_IMAGE_NAME = ${IMAGE_NAME}
+endif
+
 # The Flyte project that we want to register under
 PROJECT=flytesnacks
-REGISTRY=docker.io/lyft
 
 .PHONY: docker_build
 docker_build:
-	NOPUSH=1 REGISTRY=${REGISTRY} IMAGE_NAME=${IMAGE_NAME} flytekit_build_image.sh .
+	NOPUSH=1 IMAGE_NAME=${IMAGE_NAME} flytekit_build_image.sh .
 
 # This should only be used by Admins to push images to the public Dockerhub repo.
 .PHONY: docker_push
 docker_push:
-	IMAGE_NAME=${IMAGE_NAME} REGISTRY=${REGISTRY} flytekit_build_image.sh .
+	IMAGE_NAME=${IMAGE_NAME} flytekit_build_image.sh .
 
 .PHONY: in_container_register_sandbox
 in_container_register_sandbox:
@@ -22,7 +30,7 @@ in_container_register_sandbox:
 
 .PHONY: register_sandbox
 register_sandbox: docker_build
-	docker run docker.io/lyft/flytecookbook:${VERSION} /usr/local/bin/flytekit_venv make in_container_register_sandbox
+	docker run ${FULL_IMAGE_NAME}:${VERSION} /usr/local/bin/flytekit_venv make in_container_register_sandbox
 
 .PHONY: in_container_serialize_sandbox
 in_container_serialize_sandbox:
@@ -32,13 +40,17 @@ in_container_serialize_sandbox:
 serialize_sandbox: docker_build
 	echo ${CURDIR}
 	mkdir ${CURDIR}/_pb_output || true
-	docker run -v ${CURDIR}/_pb_output:/tmp/output docker.io/lyft/flytecookbook:${VERSION} make in_container_serialize_sandbox
+	docker run -v ${CURDIR}/_pb_output:/tmp/output ${FULL_IMAGE_NAME}:${VERSION} make in_container_serialize_sandbox
 
 .PHONY: enter_sandbox
 enter_sandbox: docker_build
-	docker run -e PROJECT=${PROJECT} -v `pwd`:/root -it docker.io/lyft/flytecookbook:${VERSION} bash
+	docker run -e PROJECT=${PROJECT} -v `pwd`:/root -it ${FULL_IMAGE_NAME}:${VERSION} bash
 
 .PHONY: run_tests
 run_tests: 
 	export PYTHONPATH=.:$(PYTHONPATH)
 	pytest tests/recipes/
+
+.PHONY: asdf
+asdf:
+	echo ${FULL_IMAGE_NAME}

--- a/cookbook/Makefile
+++ b/cookbook/Makefile
@@ -11,6 +11,7 @@ REGISTRY=docker.io/lyft
 docker_build:
 	NOPUSH=1 REGISTRY=${REGISTRY} IMAGE_NAME=${IMAGE_NAME} flytekit_build_image.sh .
 
+# This should only be used by Admins to push images to the public Dockerhub repo.
 .PHONY: docker_push
 docker_push:
 	IMAGE_NAME=${IMAGE_NAME} REGISTRY=${REGISTRY} flytekit_build_image.sh .

--- a/cookbook/Makefile
+++ b/cookbook/Makefile
@@ -11,7 +11,7 @@ REGISTRY=docker.io/lyft
 docker_build:
 	NOPUSH=1 REGISTRY=${REGISTRY} IMAGE_NAME=${IMAGE_NAME} flytekit_build_image.sh .
 
-.PHONY: docker_build
+.PHONY: docker_push
 docker_push:
 	IMAGE_NAME=${IMAGE_NAME} REGISTRY=${REGISTRY} flytekit_build_image.sh .
 
@@ -20,7 +20,7 @@ in_container_register_sandbox:
 	pyflyte -p ${PROJECT} -d development --config /root/sandbox.config register workflows
 
 .PHONY: register_sandbox
-register_sandbox: docker_push
+register_sandbox: docker_build
 	docker run docker.io/lyft/flytecookbook:${VERSION} /usr/local/bin/flytekit_venv make in_container_register_sandbox
 
 .PHONY: in_container_serialize_sandbox

--- a/cookbook/Makefile
+++ b/cookbook/Makefile
@@ -51,7 +51,3 @@ enter_sandbox: docker_build
 run_tests: 
 	export PYTHONPATH=.:$(PYTHONPATH)
 	pytest tests/recipes/
-
-.PHONY: asdf
-asdf:
-	echo ${FULL_IMAGE_NAME}

--- a/cookbook/Makefile
+++ b/cookbook/Makefile
@@ -28,11 +28,11 @@ register_sandbox: docker_build
 in_container_serialize_sandbox:
 	pyflyte -p ${PROJECT} -d development --config /root/sandbox.config serialize workflows -f /tmp/output
 
-# TODO: Get rid of the backticks in the future
 .PHONY: serialize_sandbox
 serialize_sandbox: docker_build
-	mkdir `pwd`/_pb_output || true
-	docker run -v `pwd`/_pb_output:/tmp/output docker.io/lyft/flytecookbook:${VERSION} make in_container_serialize_sandbox
+	echo ${CURDIR}
+	mkdir ${CURDIR}/_pb_output || true
+	docker run -v ${CURDIR}/_pb_output:/tmp/output docker.io/lyft/flytecookbook:${VERSION} make in_container_serialize_sandbox
 
 .PHONY: enter_sandbox
 enter_sandbox: docker_build

--- a/cookbook/Makefile
+++ b/cookbook/Makefile
@@ -19,7 +19,8 @@ PROJECT=flytesnacks
 docker_build:
 	NOPUSH=1 IMAGE_NAME=${IMAGE_NAME} flytekit_build_image.sh .
 
-# This should only be used by Admins to push images to the public Dockerhub repo.
+# This should only be used by Admins to push images to the public Dockerhub repo. Make sure you
+# specify REGISTRY=docker.io/lyft before the make command otherwise this won't actually push
 .PHONY: docker_push
 docker_push:
 	IMAGE_NAME=${IMAGE_NAME} flytekit_build_image.sh .

--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -26,4 +26,28 @@ Follow instructions in the main Flyte documentation.
 
 All the commands in this book assume that you are using Docker Desktop. If you are using minikube or another K8s deployment, the commands will need to be modified.
 
+## Using Locally
 
+Please ensure that you have a virtual environment installed and activated.
+
+### Make Targets
+
+* To build the image
+
+```
+make docker_build
+```
+
+* To register
+
+```
+make docker_push
+```
+
+The above commands will produce and use images with no registry in the name - it will just be `flytecookbook:<sha>`. If you would like to push to a registry like ECR or DockerHub, please prepend a `REGISTRY` to the commands. 
+
+* To push the image
+
+```
+REGISTRY=docker.io/corp make docker_push
+```

--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -41,7 +41,7 @@ make docker_build
 * To register
 
 ```
-make docker_push
+make register_sandbox
 ```
 
 The above commands will produce and use images with no registry in the name - it will just be `flytecookbook:<sha>`. If you would like to push to a registry like ECR or DockerHub, please prepend a `REGISTRY` to the commands. 

--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -3,7 +3,6 @@
 This is a collection of short "how to" articles demonstrating the various capabilities and idiomatic usage of Flytekit.
 Note this currently does not include articles/tid-bits on how to use the Flyte platform at large, though in the future we may expand it to that.
 
-
 ## Contents   
 1. [Write and Execute a Task](recipes/task/README.md)
 2. [Working with Types](recipes/types/README.md)
@@ -20,34 +19,29 @@ Note this currently does not include articles/tid-bits on how to use the Flyte p
 13. [Composing a Workflow from shared tasks and workflows](recipes/shared/README.md)
 14. [Different container per task](recipes/differentcontainers/README.md)
 
+Each example is organized into a separate folder at this layer, and each has the Readme file linked to in the Contents, as well as supporting .py and .ipynb files, some of which contain information in a lot more depth.
+
 ## Setup
 
-Follow instructions in the main Flyte documentation.
+Careful care has been taken to ensure that all the .py files contained in this guide are fully usable and compilable into Flyte entities. Readers that want to run these workflows for themselves should
 
-All the commands in this book assume that you are using Docker Desktop. If you are using minikube or another K8s deployment, the commands will need to be modified.
+1. Follow instructions in the main Flyte documentation to set up a local Flyte cluster. All the commands in this book assume that you are using Docker Desktop. If you are using minikube or another K8s deployment, the commands will need to be modified.
+1. Please also ensure that you have a Python virtual environment installed and activated, and have pip installed the requirements.
+1. Use flyte-cli to create a project named `flytesnacks` (the name the Makefile is set up to use).
 
-## Using Locally
+## Using the Cookbook
 
-Please ensure that you have a virtual environment installed and activated.
+The examples written in this cookbook are meant to used in two ways, as a reference to read, and a live project to iterate and test on your local (or EKS/GCP/etc K8s cluster). To make some simple changes to the code in this cookbook to just try things out, or to just see it run on your local cluster, the iteration cycle should be
 
-### Make Targets
+1. Make your changes and commit (the steps below require a clean git tree).
+1. Activate your Python virtual environment with the requirements installed.
+1. `make docker_build` This will build the image tagged with just `flytecookbook:<sha>`, no registry will be prefixed.
+1. `make register_sandbox` This will register the Flyte entities in this cookbook against your local installation.
 
-* To build the image
+If you are just iterating locally, there is no need to push your Docker image. For Docker for Desktop at least, locally built images will be available for use in its K8s cluster.
 
-```
-make docker_build
-```
+If you would like to later push your image to a registry (Dockerhub, ECR, etc.), you can
 
-* To register
-
-```
-make register_sandbox
-```
-
-The above commands will produce and use images with no registry in the name - it will just be `flytecookbook:<sha>`. If you would like to push to a registry like ECR or DockerHub, please prepend a `REGISTRY` to the commands. 
-
-* To push the image
-
-```
+```bash
 REGISTRY=docker.io/corp make docker_push
-```
+``` 


### PR DESCRIPTION
I don't think it's necessary to remove the tag entirely actually, so just changing the make target so that it doesn't try to push the image.  I think I'm okay keeping the registry path as part of the image name for now.  Pods created by propeller will have image pull ifnotpresent anyways. 