### PR TITLE
Portable examples

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -7,7 +7,7 @@ ENV LC_ALL C.UTF-8
 ENV PYTHONPATH /app
 
 # Install Python3 and other basics
-RUN apt-get update && apt-get install -y python3.6 python3.6-venv make build-essential libssl-dev python3-venv python3-pip curl 
+RUN apt-get update && apt-get install -y python3.6 python3.6-venv make build-essential libssl-dev python3-venv python3-pip curl
 
 # opencv support
 RUN apt-get install -y libsm6 libxext6 libxrender-dev

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -7,14 +7,18 @@ ENV LC_ALL C.UTF-8
 ENV PYTHONPATH /app
 
 # Install Python3 and other basics
-RUN apt-get update && apt-get install -y python3.6 python3.6-venv make build-essential libssl-dev python3-venv python3-pip curl
+RUN apt-get update && apt-get install -y python3.6 python3.6-venv make build-essential libssl-dev python3-venv python3-pip curl 
 
 # opencv support
-RUN apt-get update && apt-get install -y libsm6 libxext6 libxrender-dev
+RUN apt-get install -y libsm6 libxext6 libxrender-dev
+
+# Google Cloud SDK & Configure gcloud
+RUN curl -sSL https://sdk.cloud.google.com | bash
+ENV PATH="$PATH:/root/google-cloud-sdk/bin"
 
 # Run this before dealing with our own virtualenv. The AWS CLI uses its own virtual environment. 
 # NOTE: We are installing multi-cloud Download managers to make the examples completely portable. In your repos, please install only the utilities for cloud providers that you use.
-RUN pip3 install awscli gsutil
+RUN pip3 install awscli
 
 # Set up a virtual environment to use with our workflows
 RUN python3.6 -m venv ${VENV}

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -12,8 +12,9 @@ RUN apt-get update && apt-get install -y python3.6 python3.6-venv make build-ess
 # opencv support
 RUN apt-get update && apt-get install -y libsm6 libxext6 libxrender-dev
 
-# Run this before dealing with our own virtualenv. The AWS CLI uses its own virtual environment
-RUN pip3 install awscli
+# Run this before dealing with our own virtualenv. The AWS CLI uses its own virtual environment. 
+# NOTE: We are installing multi-cloud Download managers to make the examples completely portable. In your repos, please install only the utilities for cloud providers that you use.
+RUN pip3 install awscli gsutil
 
 # Set up a virtual environment to use with our workflows
 RUN python3.6 -m venv ${VENV}

--- a/python/README.md
+++ b/python/README.md
@@ -17,9 +17,16 @@ NOTE: these workflows are written and configured to run in Sandbox mode (Minio i
 docker run --network host -e FLYTE_PLATFORM_URL='127.0.0.1:30081' lyft/flytesnacks:b347efa300832f96d6cc0900a2aa6fbf6aad98da pyflyte -p flytesnacks -d development -c sandbox.config register workflows
 ```
 
-### Register the examples in Flyte environment running in some cloud providers with a different Blob Store
+### Register the examples in Flyte environment running in some cloud providers with a different Blob Store.
+If you directly try to run the example with the default configuration **sandbox.config** then sandbox.config instructs the workflow to use **s3://my-s3-bucket/** as scratch prefix to store
+intermediate outputs from any step execution, where flytekit is used to store the data. But, in a hosted environment, the administrator usually configures flyte to use a some bucket in the available
+blob store. For example on AWS, they would create a new **S3 bucket** while on GCP they might create a new **GCS container**
+
+Thus the previous command can be modified to work with the new hosted environment, without changing any code.
+*Caveat: The code should use flytekit constructs to write data.*
+
 ```bash
-docker run --network host -e FLYTE_PLATFORM_URL='127.0.0.1:30081' -e FLYTE_AUTH_RAW_OUTPUT_DATA_PREFIX='<replace this>' lyft/flytesnacks:b347efa300832f96d6cc0900a2aa6fbf6aad98da pyflyte -p flytesnacks -d development -c sandbox.config register workflows
+docker run --network host -e FLYTE_PLATFORM_URL='<replace with cloud hosted flyte-endpoint>' -e FLYTE_AUTH_RAW_OUTPUT_DATA_PREFIX='<replace this>' lyft/flytesnacks:b347efa300832f96d6cc0900a2aa6fbf6aad98da pyflyte -p flytesnacks -d development -c sandbox.config register workflows
 ```
 **<replace this>** -> Replace with a prefix for the destination Blob store bucket e.g. **s3://my-bucket/xyz/** or **gs://my-bucket/xyz/** 
 s3 -> AWS Simple storage service

--- a/python/README.md
+++ b/python/README.md
@@ -9,6 +9,22 @@ aim is to provide canonical examples of various mechanics available in Flyte, an
  - How to accept inputs and produce outputs from a task and a workflow.
  - How to use complex datatypes like - Schemas, Blobs and CSVs.
 
+## Run these examples in an existing Flyte Installation
+NOTE: these workflows are written and configured to run in Sandbox mode (Minio instead of using cloud blob stores). But, this can be easily overridden. Follow the steps
+
+ ### Register the examples in Flyte Sandbox environment
+```bash
+docker run --network host -e FLYTE_PLATFORM_URL='127.0.0.1:30081' lyft/flytesnacks:b347efa300832f96d6cc0900a2aa6fbf6aad98da pyflyte -p flytesnacks -d development -c sandbox.config register workflows
+```
+
+### Register the examples in Flyte environment running in some cloud providers with a different Blob Store
+```bash
+docker run --network host -e FLYTE_PLATFORM_URL='127.0.0.1:30081' -e FLYTE_AUTH_RAW_OUTPUT_DATA_PREFIX='<replace this>' lyft/flytesnacks:b347efa300832f96d6cc0900a2aa6fbf6aad98da pyflyte -p flytesnacks -d development -c sandbox.config register workflows
+```
+**<replace this>** -> Replace with a prefix for the destination Blob store bucket e.g. **s3://my-bucket/xyz/** or **gs://my-bucket/xyz/** 
+s3 -> AWS Simple storage service
+gs -> Google Cloud Storage
+
 
 ## Contents
 1. [Simple Single Task Workflow](single_step)

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,4 +1,5 @@
-flytekit[schema]==0.12.1
+#flytekit[schema]==0.12.1
+https://github.com/lyft/flytekit/archive/b44ac82955e421cbc2b01da397313c984e0b71a9.zip#egg=flytekit[schema,sidecar]
 opencv-python==3.4.4.19
 xgboost==0.90
 scikit-learn==0.21.3

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,4 +1,4 @@
-flytekit[schema]==0.3.0
+flytekit[schema]==0.11.6
 opencv-python==3.4.4.19
 xgboost==0.90
 scikit-learn==0.21.3

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,4 @@
-#flytekit[schema]==0.12.1
-https://github.com/lyft/flytekit/archive/978670a6e0c69f3ce73c18cfd4ccce6fdb91ee7f.zip#egg=flytekit[schema,sidecar]
+flytekit[schema]==0.12.1
 opencv-python==3.4.4.19
 xgboost==0.90
 scikit-learn==0.21.3

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,5 @@
 #flytekit[schema]==0.12.1
-https://github.com/lyft/flytekit/archive/b44ac82955e421cbc2b01da397313c984e0b71a9.zip#egg=flytekit[schema,sidecar]
+https://github.com/lyft/flytekit/archive/978670a6e0c69f3ce73c18cfd4ccce6fdb91ee7f.zip#egg=flytekit[schema,sidecar]
 opencv-python==3.4.4.19
 xgboost==0.90
 scikit-learn==0.21.3

--- a/python/sandbox-gcp.config
+++ b/python/sandbox-gcp.config
@@ -8,4 +8,4 @@ insecure=True
 cloud_provider=gcp
 
 [gcp]
-gcs_prefix=gs://bhram-flyte
+gcs_prefix=gs://my-bucket

--- a/python/sandbox-gcp.config
+++ b/python/sandbox-gcp.config
@@ -9,3 +9,6 @@ assumable_iam_role:arn:aws:iam::123:role/test-role
 url=127.0.0.1:30081
 insecure=True
 cloud_provider=gcp
+
+[gcp]
+gcs_prefix=gs://bhram-flyte

--- a/python/sandbox-gcp.config
+++ b/python/sandbox-gcp.config
@@ -1,0 +1,11 @@
+[sdk]
+workflow_packages=single_step,multi_step_linear
+python_venv=flytekit_venv
+
+[auth]
+assumable_iam_role:arn:aws:iam::123:role/test-role
+
+[platform]
+url=127.0.0.1:30081
+insecure=True
+cloud_provider=gcp

--- a/python/sandbox-gcp.config
+++ b/python/sandbox-gcp.config
@@ -2,9 +2,6 @@
 workflow_packages=single_step,multi_step_linear
 python_venv=flytekit_venv
 
-[auth]
-assumable_iam_role:arn:aws:iam::123:role/test-role
-
 [platform]
 url=127.0.0.1:30081
 insecure=True

--- a/python/sandbox-gcp.config
+++ b/python/sandbox-gcp.config
@@ -2,19 +2,13 @@
 workflow_packages=single_step,multi_step_linear
 python_venv=flytekit_venv
 
-<<<<<<< HEAD
-=======
 [auth]
 assumable_iam_role:arn:aws:iam::123:role/test-role
 
->>>>>>> master
 [platform]
 url=127.0.0.1:30081
 insecure=True
 cloud_provider=gcp
-<<<<<<< HEAD
 
 [gcp]
 gcs_prefix=gs://my-bucket
-=======
->>>>>>> master

--- a/python/sandbox.config
+++ b/python/sandbox.config
@@ -11,7 +11,3 @@ insecure=True
 
 [aws]
 s3_shard_formatter=s3://my-s3-bucket/{}
-s3_shard_string_length=2
-endpoint=http://minio:9000
-access_key_id=minio
-secret_access_key=miniostorage

--- a/python/sandbox.config
+++ b/python/sandbox.config
@@ -10,7 +10,7 @@ assumable_iam_role:arn:aws:iam::123:role/test-role
 url=127.0.0.1:30081
 insecure=True
 
-#[aws]
+[aws]
 # Deprecated. Please use the raw_output_data_prefix above
 # See the "Customize Offloaded Data Location" chapter in the cookbook for more information
-#s3_shard_formatter=s3://my-s3-bucket/{}
+s3_shard_formatter=s3://my-s3-bucket/{}

--- a/python/sandbox.config
+++ b/python/sandbox.config
@@ -4,12 +4,13 @@ python_venv=flytekit_venv
 
 [auth]
 raw_output_data_prefix=s3://my-s3-bucket/offloaded-data-storage
+assumable_iam_role:arn:aws:iam::123:role/test-role
 
 [platform]
 url=127.0.0.1:30081
 insecure=True
 
-[aws]
+#[aws]
 # Deprecated. Please use the raw_output_data_prefix above
 # See the "Customize Offloaded Data Location" chapter in the cookbook for more information
-s3_shard_formatter=s3://my-s3-bucket/{}
+#s3_shard_formatter=s3://my-s3-bucket/{}

--- a/python/sandbox.config
+++ b/python/sandbox.config
@@ -13,5 +13,5 @@ insecure=True
 [aws]
 # Deprecated. Please use the raw_output_data_prefix above
 # See the "Customize Offloaded Data Location" chapter in the cookbook for more information
-s3_shard_formatter=s3://my-s3-bucket/{}
+#s3_shard_formatter=s3://my-s3-bucket/{}
 enable_debug=True

--- a/python/sandbox.config
+++ b/python/sandbox.config
@@ -14,3 +14,4 @@ insecure=True
 # Deprecated. Please use the raw_output_data_prefix above
 # See the "Customize Offloaded Data Location" chapter in the cookbook for more information
 s3_shard_formatter=s3://my-s3-bucket/{}
+enable_debug=True


### PR DESCRIPTION
One step closer to completely portable examples.
 - Just one change is required
for AWS set the `s3_shard_formatter: s3://<your-bucket-name>/`
for GCP set the `gcs_prefix: gs://<your-bucket>`
- This is being worked on in the following weeks, which can completely eliminate this requirement