### PR TITLE
Annotations import nits

### DIFF
--- a/cookbook_se/Makefile
+++ b/cookbook_se/Makefile
@@ -20,7 +20,7 @@ serialize:
 	echo ${CURDIR}
 	mkdir ${CURDIR}/_pb_output || true
 	rm ${CURDIR}/_pb_output/* || true
-	pyflyte -c sandbox.config --pkgs recipes serialize --in-container-config-path /root/sandbox.config --local-source-root ${CURDIR} --image flytecookbook:${VERSION} workflows -f _pb_output/
+	pyflyte -c sandbox.config --pkgs recipes serialize --in-container-config-path /root/sandbox.config --local-source-root ${CURDIR} --image ${FULL_IMAGE_NAME}:${VERSION} workflows -f _pb_output/
 
 .PHONY: register
 register:

--- a/cookbook_se/recipes/common/Makefile.common
+++ b/cookbook_se/recipes/common/Makefile.common
@@ -56,7 +56,7 @@ install-piptools:
 
 .PHONY: setup
 setup: install-piptools ## Install requirements
-	pip-sync requirements.txt dev-requirements.txt
+	pip-sync dev-requirements.txt
 
 .PHONY: lint
 lint: ## Run linters


### PR DESCRIPTION
* Add the `FULL_IMAGE_NAME` env var to the `make serialize` command so that prepending with `REGISTRY` works.
* Make make setup to install only the dev requirements as the dev requirements and the default requirements have slightly different versions of grpcio. This is because the dev-requirements.in file references the requirements.in file and not the requirements.txt file.